### PR TITLE
fix: ownership fix for portfolios + minor resume error handling

### DIFF
--- a/src/capstone_project_team_5/api/routes/resumes.py
+++ b/src/capstone_project_team_5/api/routes/resumes.py
@@ -205,7 +205,7 @@ def update_resume_endpoint(
     merged_bullets = update_fields.get("bullet_points", existing["bullet_points"])
     merged_snapshot = update_fields.get("analysis_snapshot", existing["analysis_snapshot"])
 
-    save_resume(
+    success = save_resume(
         username=username,
         project_id=project_id,
         title=merged_title,
@@ -213,6 +213,11 @@ def update_resume_endpoint(
         bullet_points=merged_bullets,
         analysis_snapshot=merged_snapshot,
     )
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to update resume. Check that the project_id is valid.",
+        )
 
     result = get_resume(username, project_id)
     if not result:

--- a/tests/test_resumes_api.py
+++ b/tests/test_resumes_api.py
@@ -411,6 +411,28 @@ class TestUpdateResume:
         )
         assert response.status_code == 404
 
+    def test_update_save_failure_returns_400(
+        self,
+        client: TestClient,
+        test_user: tuple[str, int],
+        test_project: int,
+    ) -> None:
+        username, _ = test_user
+        _create_resume(client, username, test_project, title="Original")
+
+        with patch("capstone_project_team_5.api.routes.resumes.save_resume", return_value=False):
+            response = client.patch(
+                f"/api/users/{username}/resumes/{test_project}",
+                json={"title": "Will Fail"},
+                headers={"X-Username": username},
+            )
+
+        assert response.status_code == 400
+        assert (
+            response.json()["detail"]
+            == "Failed to update resume. Check that the project_id is valid."
+        )
+
     def test_no_auth_returns_401(self, client: TestClient, test_user: tuple[str, int]) -> None:
         username, _ = test_user
         response = client.patch(


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR contains small housekeeping fixes for API endpoint correctness and test reliability.

1. Updated POST `/api/portfolio/items` to validate that `portfolio_id` belongs to the requesting user (username) before creating/updating a PortfolioItem.
2. If the portfolio is missing or owned by a different user, endpoint now returns 404 with Portfolio not found for user.
3. Updated PATCH `/api/users/{username}/resumes/{project_id}` to check the return value of `save_resume(...)`.
If persistence fails, endpoint now returns `400` instead of potentially returning a false success response.


**Closes:** #337 (issue number)

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [x] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

1. `tests/test_portfolio_api.py` now uses unique uploaded project names to avoid cross-test collisions (409) from reused names.
2. Added regression test to ensure cross-user portfolio_id assignment is rejected.
3. Added regression test for resume patch when save fails.

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile
