### PR TITLE
fix: set auth username header on login and restore from localStorage

### DIFF
--- a/frontend/renderer/src/App.jsx
+++ b/frontend/renderer/src/App.jsx
@@ -47,7 +47,10 @@ export default function App() {
 
       // 2. Restore persisted username (may be absent on first run)
       const savedUsername = localStorage.getItem('zip2job_username')
-      if (savedUsername) window.api.setUsername(savedUsername)
+      if (savedUsername) {
+        window.api.setAuthUsername(savedUsername)
+        window.api.setUsername(savedUsername)
+      }
 
       // 3. If no saved username → definitely first-run, skip auth'd calls
       if (!savedUsername) {
@@ -152,6 +155,7 @@ function ConsentSetup({ onDone }) {
     try {
       const fn = authMode === 'register' ? window.api.register : window.api.login
       const res = await fn({ username: username.trim(), password })
+      window.api.setAuthUsername(res.username)
       window.api.setUsername(res.username)
       // Load available services list for the consent step
       const data = await window.api.getAvailableServices()
@@ -625,7 +629,6 @@ function Dashboard() {
         name: file.name,
         type: file.type || 'application/zip',
         bytes,
-        signal: controller.signal,
       })
 
       const actions = result?.actions ?? []


### PR DESCRIPTION
> [!NOTE]  
> CI currently broken, fixed by https://github.com/COSC-499-W2025/capstone-project-team-5/pull/359


## 📝 Description

Fixes file upload, and uses `setAuthUsername` to correctly populate the username header

**Closes:** #357 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [ ] Manually verified login → portfolio create no longer throws Cannot read properties of null
- [ ] Manually verified ZIP upload completes and navigates to Projects page

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>