### PR TITLE
feat: resume entry editor (2/4)

### DIFF
--- a/frontend/renderer/src/lib/resumes.js
+++ b/frontend/renderer/src/lib/resumes.js
@@ -1,3 +1,22 @@
+export const EMPTY_RESUME_FORM = {
+  project_id: '',
+  project_name: '',
+  title: '',
+  description: '',
+  analysis_snapshot: '',
+  bullet_points: [''],
+}
+
+function compact(values) {
+  return values
+    .map((value) => String(value ?? '').trim())
+    .filter(Boolean)
+}
+
+function unique(values) {
+  return [...new Set(compact(values))]
+}
+
 export function normalizeResumeItems(payload) {
   if (Array.isArray(payload)) {
     return payload
@@ -33,4 +52,50 @@ export function formatResumeDate(value) {
     month: 'short',
     day: 'numeric',
   })
+}
+
+export function parseSnapshotInput(value) {
+  return unique(String(value ?? '').split(',')).slice(0, 8)
+}
+
+export function prepareBulletPoints(values) {
+  return compact(values)
+}
+
+export function getAvailableResumeProjects(projects, resumes, currentProjectId = null) {
+  const usedProjectIds = new Set(
+    resumes
+      .map((resume) => resume?.project_id)
+      .filter(
+        (projectId) =>
+          projectId !== null && projectId !== undefined && projectId !== currentProjectId
+      )
+  )
+
+  return projects.filter((project) => !usedProjectIds.has(project.id))
+}
+
+export function buildResumeDraft(project, analysis) {
+  const snapshot = unique([
+    analysis?.language,
+    analysis?.framework,
+    ...(analysis?.tools ?? []),
+    ...(analysis?.other_languages ?? []),
+    ...(analysis?.practices ?? []),
+  ]).slice(0, 8)
+
+  const bulletPoints = prepareBulletPoints(
+    (analysis?.resume_bullets?.length ? analysis.resume_bullets : analysis?.ai_bullets) ?? []
+  )
+
+  const summaryPrefix = snapshot.length > 0 ? `Built with ${snapshot.slice(0, 4).join(', ')}.` : ''
+
+  return {
+    project_id: String(project?.id ?? ''),
+    project_name: analysis?.name ?? project?.name ?? '',
+    title: analysis?.name ?? project?.name ?? '',
+    description: summaryPrefix,
+    analysis_snapshot: snapshot.join(', '),
+    bullet_points: bulletPoints.length > 0 ? bulletPoints : [''],
+  }
 }

--- a/frontend/renderer/src/pages/resumes/ResumesPage.jsx
+++ b/frontend/renderer/src/pages/resumes/ResumesPage.jsx
@@ -3,10 +3,16 @@ import { useApp } from '../../app/context/AppContext'
 import EmptyState from '../../components/EmptyState'
 import InlineError from '../../components/InlineError'
 import PageHeader from '../../components/PageHeader'
+import { getProjectItems } from '../../lib/projects'
 import {
+  EMPTY_RESUME_FORM,
+  buildResumeDraft,
   formatResumeDate,
+  getAvailableResumeProjects,
   hasResumeProfile,
   normalizeResumeItems,
+  parseSnapshotInput,
+  prepareBulletPoints,
   sortResumesByUpdatedAt,
 } from '../../lib/resumes'
 
@@ -32,12 +38,31 @@ function ReadinessItem({ label, ready, detail }) {
 
 export default function ResumesPage() {
   const { user, apiOk } = useApp()
+
   const [resumes, setResumes] = useState([])
+  const [projects, setProjects] = useState([])
   const [profile, setProfile] = useState(null)
   const [workCount, setWorkCount] = useState(0)
   const [educationCount, setEducationCount] = useState(0)
+  const [llmConfig, setLlmConfig] = useState({ is_allowed: false, model_preferences: [] })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+
+  const [showForm, setShowForm] = useState(false)
+  const [editingProjectId, setEditingProjectId] = useState(null)
+  const [form, setForm] = useState(EMPTY_RESUME_FORM)
+  const [useAiAssist, setUseAiAssist] = useState(false)
+  const [draftLoading, setDraftLoading] = useState(false)
+  const [draftStatus, setDraftStatus] = useState('')
+  const [formError, setFormError] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [confirmId, setConfirmId] = useState(null)
+
+  useEffect(() => {
+    if (!llmConfig?.is_allowed) {
+      setUseAiAssist(false)
+    }
+  }, [llmConfig])
 
   useEffect(() => {
     if (!apiOk || !user?.username) {
@@ -50,11 +75,20 @@ export default function ResumesPage() {
       setLoading(true)
       setError('')
 
-      const [resumeResult, profileResult, workResult, educationResult] = await Promise.allSettled([
+      const [
+        resumeResult,
+        profileResult,
+        workResult,
+        educationResult,
+        projectResult,
+        llmResult,
+      ] = await Promise.allSettled([
         window.api.getResumes(user.username),
         window.api.getProfile(user.username),
         window.api.getWorkExperiences(user.username),
         window.api.getEducations(user.username),
+        window.api.getProjects(),
+        window.api.getLLMConfig(),
       ])
 
       if (cancelled) {
@@ -68,10 +102,22 @@ export default function ResumesPage() {
         setError(resumeResult.reason?.message || 'Failed to load resume entries.')
       }
 
+      if (projectResult.status === 'fulfilled') {
+        setProjects(getProjectItems(projectResult.value))
+      } else {
+        setProjects([])
+        setError((current) => current || projectResult.reason?.message || 'Failed to load projects.')
+      }
+
       setProfile(profileResult.status === 'fulfilled' ? profileResult.value : null)
       setWorkCount(workResult.status === 'fulfilled' ? (workResult.value?.length ?? 0) : 0)
       setEducationCount(
         educationResult.status === 'fulfilled' ? (educationResult.value?.length ?? 0) : 0
+      )
+      setLlmConfig(
+        llmResult.status === 'fulfilled'
+          ? llmResult.value ?? { is_allowed: false, model_preferences: [] }
+          : { is_allowed: false, model_preferences: [] }
       )
       setLoading(false)
     }
@@ -83,93 +129,479 @@ export default function ResumesPage() {
     }
   }, [apiOk, user?.username])
 
+  function openCreate() {
+    setShowForm(true)
+    setEditingProjectId(null)
+    setForm(EMPTY_RESUME_FORM)
+    setUseAiAssist(Boolean(llmConfig?.is_allowed))
+    setDraftStatus('')
+    setFormError('')
+    setConfirmId(null)
+  }
+
+  function openEdit(item) {
+    setShowForm(true)
+    setEditingProjectId(item.project_id)
+    setForm({
+      project_id: String(item.project_id),
+      project_name: item.project_name ?? '',
+      title: item.title ?? item.project_name ?? '',
+      description: item.description ?? '',
+      analysis_snapshot: (item.analysis_snapshot ?? []).join(', '),
+      bullet_points: item.bullet_points?.length ? item.bullet_points : [''],
+    })
+    setDraftStatus('')
+    setFormError('')
+    setConfirmId(null)
+  }
+
+  function cancelForm() {
+    setShowForm(false)
+    setEditingProjectId(null)
+    setForm(EMPTY_RESUME_FORM)
+    setDraftStatus('')
+    setFormError('')
+  }
+
+  function updateField(key, value) {
+    setForm((current) => ({ ...current, [key]: value }))
+  }
+
+  function updateBullet(index, value) {
+    setForm((current) => ({
+      ...current,
+      bullet_points: current.bullet_points.map((bullet, bulletIndex) =>
+        bulletIndex === index ? value : bullet
+      ),
+    }))
+  }
+
+  function addBullet() {
+    setForm((current) => ({
+      ...current,
+      bullet_points: [...current.bullet_points, ''],
+    }))
+  }
+
+  function removeBullet(index) {
+    setForm((current) => {
+      const nextBullets = current.bullet_points.filter((_, bulletIndex) => bulletIndex !== index)
+      return {
+        ...current,
+        bullet_points: nextBullets.length > 0 ? nextBullets : [''],
+      }
+    })
+  }
+
+  const availableProjects = getAvailableResumeProjects(projects, resumes, editingProjectId)
   const hasProfile = hasResumeProfile(profile)
+
+  async function hydrateDraft(projectIdValue) {
+    updateField('project_id', projectIdValue)
+    setDraftStatus('')
+    setFormError('')
+
+    if (!projectIdValue) {
+      setForm((current) => ({
+        ...current,
+        project_id: '',
+        project_name: '',
+        title: '',
+        description: '',
+        analysis_snapshot: '',
+        bullet_points: [''],
+      }))
+      return
+    }
+
+    const project = projects.find((item) => String(item.id) === String(projectIdValue))
+    if (!project) {
+      return
+    }
+
+    setDraftLoading(true)
+    setForm((current) => ({
+      ...current,
+      project_id: String(project.id),
+      project_name: project.name,
+      title: project.name,
+    }))
+
+    try {
+      let analysis = null
+      let nextStatus = ''
+
+      if (useAiAssist && llmConfig?.is_allowed) {
+        try {
+          analysis = await window.api.analyzeProject(project.id, { useAi: true })
+          nextStatus = 'AI-assisted draft ready.'
+        } catch {
+          analysis = await window.api.analyzeProject(project.id, { useAi: false })
+          nextStatus = 'AI assist failed. Local analysis loaded instead.'
+        }
+      } else {
+        analysis = await window.api.analyzeProject(project.id, { useAi: false })
+        nextStatus = 'Local analysis draft ready.'
+      }
+
+      const nextDraft = buildResumeDraft(project, analysis)
+      setForm(nextDraft)
+      setDraftStatus(nextStatus)
+    } catch (draftError) {
+      setFormError(draftError?.message || 'Failed to build a resume draft for this project.')
+      setDraftStatus('')
+    } finally {
+      setDraftLoading(false)
+    }
+  }
+
+  async function handleSave(event) {
+    event.preventDefault()
+
+    const nextBullets = prepareBulletPoints(form.bullet_points)
+    if (!form.project_id) {
+      setFormError('Select a project to build a resume entry.')
+      return
+    }
+    if (!form.title.trim()) {
+      setFormError('A resume title is required.')
+      return
+    }
+    if (nextBullets.length === 0) {
+      setFormError('Add at least one bullet point before saving.')
+      return
+    }
+
+    setSaving(true)
+    setFormError('')
+
+    const commonPayload = {
+      title: form.title.trim(),
+      description: form.description.trim(),
+      bullet_points: nextBullets,
+      analysis_snapshot: parseSnapshotInput(form.analysis_snapshot),
+    }
+
+    try {
+      let savedItem = null
+
+      if (editingProjectId) {
+        savedItem = await window.api.updateResume(user.username, editingProjectId, commonPayload)
+        setResumes((current) =>
+          sortResumesByUpdatedAt(
+            current.map((item) => (item.project_id === editingProjectId ? savedItem : item))
+          )
+        )
+      } else {
+        savedItem = await window.api.createResume(user.username, {
+          project_id: parseInt(form.project_id, 10),
+          ...commonPayload,
+        })
+        setResumes((current) => sortResumesByUpdatedAt([savedItem, ...current]))
+      }
+
+      cancelForm()
+    } catch (saveError) {
+      setFormError(saveError?.message || 'Failed to save the resume entry.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete(projectId) {
+    try {
+      await window.api.deleteResume(user.username, projectId)
+      setResumes((current) => current.filter((item) => item.project_id !== projectId))
+      setConfirmId(null)
+    } catch (deleteError) {
+      setError(deleteError?.message || 'Failed to delete the resume entry.')
+    }
+  }
 
   return (
     <div className="animate-fade-up space-y-6">
       <PageHeader
         title="Resumes"
-        description="Review saved resume entries and verify the profile data needed before editing and generating the final PDF."
+        description="Shape project analysis into saved resume entries. PDF preview and download are split into the next PR."
+        action={!showForm && (
+          <button
+            type="button"
+            onClick={openCreate}
+            disabled={availableProjects.length === 0}
+            className="btn-primary text-xs disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {availableProjects.length === 0 ? 'All Projects Added' : '+ Add Resume Entry'}
+          </button>
+        )}
       />
 
       <InlineError message={error} />
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1.65fr)_320px]">
-        <div className="space-y-4">
+        <div className="space-y-6">
+          {showForm && (
+            <form onSubmit={handleSave} className="card space-y-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-sm font-bold">
+                    {editingProjectId ? 'Edit Resume Entry' : 'Build Resume Entry'}
+                  </h2>
+                  <p className="mt-1 text-xs text-muted">
+                    Save polished project bullets now. Preview and export arrive in the next stacked PR.
+                  </p>
+                </div>
+                <button type="button" className="btn-ghost text-xs" onClick={cancelForm}>
+                  Cancel
+                </button>
+              </div>
+
+              <InlineError message={formError} />
+
+              {!editingProjectId && (
+                <div className="rounded-lg border border-border bg-elevated/70 p-3">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <div className="text-xs font-semibold text-ink">Draft Assist</div>
+                      <p className="mt-1 text-2xs leading-relaxed text-muted">
+                        Use AI when consent allows it, otherwise build from local project analysis.
+                      </p>
+                    </div>
+                    <label className="flex items-center gap-2 text-xs text-ink">
+                      <input
+                        type="checkbox"
+                        checked={useAiAssist}
+                        onChange={(event) => setUseAiAssist(event.target.checked)}
+                        disabled={!llmConfig?.is_allowed || draftLoading}
+                      />
+                      Use AI Assist
+                    </label>
+                  </div>
+                  <p className="mt-2 font-mono text-2xs uppercase tracking-widest text-muted">
+                    {llmConfig?.is_allowed
+                      ? `AI ready${llmConfig.model_preferences?.[0] ? ` · ${llmConfig.model_preferences[0]}` : ''}`
+                      : 'Local analysis only'}
+                  </p>
+                </div>
+              )}
+
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                {editingProjectId ? (
+                  <div className="rounded-lg border border-border bg-elevated/60 px-3 py-2">
+                    <div className="text-2xs uppercase tracking-widest text-muted">Project</div>
+                    <div className="mt-1 text-sm font-semibold text-ink">{form.project_name}</div>
+                  </div>
+                ) : (
+                  <label className="space-y-1">
+                    <span className="font-mono text-2xs uppercase tracking-widest text-muted">
+                      Project
+                    </span>
+                    <select
+                      value={form.project_id}
+                      onChange={(event) => hydrateDraft(event.target.value)}
+                      className="input"
+                      disabled={draftLoading || availableProjects.length === 0}
+                    >
+                      <option value="">Choose a project…</option>
+                      {availableProjects.map((project) => (
+                        <option key={project.id} value={project.id}>
+                          {project.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+
+                <label className="space-y-1">
+                  <span className="font-mono text-2xs uppercase tracking-widest text-muted">
+                    Title
+                  </span>
+                  <input
+                    className="input"
+                    value={form.title}
+                    onChange={(event) => updateField('title', event.target.value)}
+                    placeholder="Project title for the resume"
+                  />
+                </label>
+              </div>
+
+              <label className="space-y-1">
+                <span className="font-mono text-2xs uppercase tracking-widest text-muted">
+                  Description
+                </span>
+                <textarea
+                  rows={3}
+                  className="input w-full"
+                  value={form.description}
+                  onChange={(event) => updateField('description', event.target.value)}
+                  placeholder="Short summary for the entry"
+                />
+              </label>
+
+              <label className="space-y-1">
+                <span className="font-mono text-2xs uppercase tracking-widest text-muted">
+                  Technologies
+                </span>
+                <input
+                  className="input"
+                  value={form.analysis_snapshot}
+                  onChange={(event) => updateField('analysis_snapshot', event.target.value)}
+                  placeholder="React, FastAPI, PostgreSQL"
+                />
+              </label>
+
+              <div className="space-y-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="font-mono text-2xs uppercase tracking-widest text-muted">
+                      Bullet Points
+                    </div>
+                    {draftStatus && <p className="mt-1 text-2xs text-muted">{draftStatus}</p>}
+                  </div>
+                  <button type="button" className="btn-ghost text-xs" onClick={addBullet}>
+                    + Add Bullet
+                  </button>
+                </div>
+
+                {draftLoading && (
+                  <div className="flex items-center gap-2 rounded-lg border border-border bg-elevated/60 px-3 py-3 text-xs text-muted">
+                    <span className="spinner" />
+                    Building a draft from project analysis…
+                  </div>
+                )}
+
+                <div className="space-y-3">
+                  {form.bullet_points.map((bullet, index) => (
+                    <div key={`${index}-${bullet.length}`} className="flex items-start gap-3">
+                      <div className="pt-2 font-mono text-2xs uppercase tracking-widest text-muted">
+                        {index + 1}
+                      </div>
+                      <textarea
+                        rows={3}
+                        className="input w-full"
+                        value={bullet}
+                        onChange={(event) => updateBullet(index, event.target.value)}
+                        placeholder="Describe the project impact, scope, and results."
+                      />
+                      <button
+                        type="button"
+                        className="btn-ghost text-xs"
+                        onClick={() => removeBullet(index)}
+                        disabled={form.bullet_points.length === 1}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="submit"
+                  disabled={saving || draftLoading}
+                  className="btn-primary text-xs disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {saving ? 'Saving…' : editingProjectId ? 'Save Changes' : 'Save Resume Entry'}
+                </button>
+                <button type="button" className="btn-ghost text-xs" onClick={cancelForm}>
+                  Cancel
+                </button>
+              </div>
+            </form>
+          )}
+
           {loading ? (
             <div className="flex justify-center py-12">
               <span className="spinner" />
             </div>
           ) : resumes.length > 0 ? (
-            resumes.map((item) => {
-              const snapshot = item.analysis_snapshot ?? []
-              const bulletCount = item.bullet_points?.length ?? 0
+            <div className="space-y-4">
+              {resumes.map((item) => {
+                const snapshot = item.analysis_snapshot ?? []
+                const bulletCount = item.bullet_points?.length ?? 0
 
-              return (
-                <article key={item.project_id} className="card space-y-4">
-                  <div className="flex flex-wrap items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <h2 className="truncate text-lg font-extrabold tracking-tight text-ink">
-                        {item.title || item.project_name}
-                      </h2>
-                      <div className="mt-1 flex flex-wrap items-center gap-3 font-mono text-2xs uppercase tracking-widest text-muted">
-                        <span>{item.project_name}</span>
-                        <span>{bulletCount} bullets</span>
-                        <span>Updated {formatResumeDate(item.updated_at)}</span>
+                return (
+                  <article key={item.project_id} className="card space-y-4">
+                    <div className="flex flex-wrap items-start justify-between gap-4">
+                      <div className="min-w-0">
+                        <h2 className="truncate text-lg font-extrabold tracking-tight text-ink">
+                          {item.title || item.project_name}
+                        </h2>
+                        <div className="mt-1 flex flex-wrap items-center gap-3 font-mono text-2xs uppercase tracking-widest text-muted">
+                          <span>{item.project_name}</span>
+                          <span>{bulletCount} bullets</span>
+                          <span>Updated {formatResumeDate(item.updated_at)}</span>
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-2">
+                        <button type="button" className="btn-ghost text-xs" onClick={() => openEdit(item)}>
+                          Edit
+                        </button>
+                        {confirmId === item.project_id ? (
+                          <>
+                            <span className="text-xs text-red-400">Delete?</span>
+                            <button
+                              type="button"
+                              className="btn-ghost text-xs text-red-400"
+                              onClick={() => handleDelete(item.project_id)}
+                            >
+                              Yes
+                            </button>
+                            <button
+                              type="button"
+                              className="btn-ghost text-xs"
+                              onClick={() => setConfirmId(null)}
+                            >
+                              No
+                            </button>
+                          </>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn-ghost text-xs"
+                            onClick={() => setConfirmId(item.project_id)}
+                          >
+                            Delete
+                          </button>
+                        )}
                       </div>
                     </div>
-                    <span className="rounded border border-border bg-elevated px-2 py-0.5 font-mono text-2xs uppercase tracking-widest text-muted">
-                      Saved Entry
-                    </span>
-                  </div>
 
-                  {item.description && (
-                    <p className="text-sm leading-relaxed text-ink/75">{item.description}</p>
-                  )}
+                    {item.description && (
+                      <p className="text-sm leading-relaxed text-ink/75">{item.description}</p>
+                    )}
 
-                  {snapshot.length > 0 && (
-                    <div className="flex flex-wrap gap-2">
-                      {snapshot.map((entry) => (
-                        <span key={entry} className="tag">
-                          {entry}
-                        </span>
+                    {snapshot.length > 0 && (
+                      <div className="flex flex-wrap gap-2">
+                        {snapshot.map((entry) => (
+                          <span key={entry} className="tag">
+                            {entry}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="space-y-2 border-t border-border pt-3">
+                      {item.bullet_points?.map((bullet) => (
+                        <div
+                          key={bullet}
+                          className="rounded-lg border border-border/70 bg-elevated/40 px-3 py-2 text-sm leading-relaxed text-ink/85"
+                        >
+                          {bullet}
+                        </div>
                       ))}
                     </div>
-                  )}
-
-                  <div className="space-y-2 border-t border-border pt-3">
-                    {item.bullet_points?.map((bullet) => (
-                      <div
-                        key={bullet}
-                        className="rounded-lg border border-border/70 bg-elevated/40 px-3 py-2 text-sm leading-relaxed text-ink/85"
-                      >
-                        {bullet}
-                      </div>
-                    ))}
-                  </div>
-                </article>
-              )
-            })
+                  </article>
+                )
+              })}
+            </div>
           ) : (
-            <EmptyState message="No resume entries yet. Editing and generation land in the next stacked PR." />
+            <EmptyState message="No resume entries yet. Add a project to start shaping the final document." />
           )}
         </div>
 
         <aside className="space-y-4 xl:sticky xl:top-6 xl:self-start">
-          <section className="card space-y-4">
-            <div>
-              <div className="font-mono text-2xs uppercase tracking-widest text-muted">
-                Resume Status
-              </div>
-              <h2 className="mt-2 text-lg font-extrabold tracking-tight text-ink">
-                Check what is ready
-              </h2>
-              <p className="mt-2 text-sm leading-relaxed text-muted">
-                This workspace already reads your saved resume entries. Editing, AI assist, and PDF preview are split into the next PR.
-              </p>
-            </div>
-          </section>
-
           <section className="card space-y-2">
             <div className="font-mono text-2xs uppercase tracking-widest text-muted">
               Readiness Checklist


### PR DESCRIPTION
## 📝 Description

Adds the interactive resume entry workflow on top of the workspace shell. This PR introduces the inline editor, project-based draft creation, the AI assist toggle, and create, update, and delete flows for saved resume entries.

**Related Issues:** #371, #224

**Closes:** N/A

---

## 🔧 Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] `npm test -- --runInBand`

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

</details>
