### PR TITLE
test: resume frontend coverage (4/4)

### DIFF
--- a/frontend/tests/App.dom.test.jsx
+++ b/frontend/tests/App.dom.test.jsx
@@ -27,7 +27,19 @@ function setupApi(overrides = {}) {
     getProjects:          jest.fn().mockResolvedValue([]),
     getSkills:            jest.fn().mockResolvedValue([]),
     getWorkExperiences:   jest.fn().mockResolvedValue([]),
+    getEducations:        jest.fn().mockResolvedValue([]),
+    getProfile:           jest.fn().mockResolvedValue(null),
     getResumes:           jest.fn().mockResolvedValue([]),
+    getLLMConfig:         jest.fn().mockResolvedValue({ is_allowed: false, model_preferences: [] }),
+    analyzeProject:       jest.fn().mockResolvedValue({}),
+    createResume:         jest.fn().mockResolvedValue({}),
+    updateResume:         jest.fn().mockResolvedValue({}),
+    deleteResume:         jest.fn().mockResolvedValue(null),
+    downloadResumePdf:    jest.fn().mockResolvedValue({
+      bytes: new ArrayBuffer(8),
+      contentType: 'application/pdf',
+      filename: 'resume.pdf',
+    }),
     ...overrides,
   }
 }
@@ -94,6 +106,21 @@ test('clicking a nav item updates the topbar title', async () => {
     const header = document.querySelector('header')
     expect(header.textContent).toMatch(/Projects/)
   })
+})
+
+test('dashboard quick action opens the resumes workspace', async () => {
+  setupApi()
+  localStorage.setItem('zip2job_username', 'alice')
+  render(<App />)
+  await waitFor(() => expect(screen.getByText('Portfolio Engine')).toBeInTheDocument())
+
+  fireEvent.click(screen.getByRole('button', { name: /generate resume/i }))
+
+  await waitFor(() => {
+    const header = document.querySelector('header')
+    expect(header.textContent).toMatch(/Resumes/)
+  })
+  expect(screen.getByRole('heading', { name: /^resumes$/i })).toBeInTheDocument()
 })
 
 test('shows username in sidebar when user is loaded', async () => {

--- a/frontend/tests/Resumes.dom.test.jsx
+++ b/frontend/tests/Resumes.dom.test.jsx
@@ -1,0 +1,284 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { AppContext } from '../renderer/src/app/context/AppContext.jsx'
+import ResumesPage from '../renderer/src/pages/resumes/ResumesPage.jsx'
+
+const PROFILE = {
+  id: 9,
+  user_id: 3,
+  first_name: 'Alice',
+  last_name: 'Nguyen',
+  email: 'alice@example.com',
+}
+
+const PROJECT_ONE = {
+  id: 1,
+  name: 'Portfolio Engine',
+  rel_path: 'portfolio-engine',
+  file_count: 12,
+}
+
+const PROJECT_TWO = {
+  id: 2,
+  name: 'Signal Board',
+  rel_path: 'signal-board',
+  file_count: 8,
+}
+
+const EXISTING_RESUME = {
+  id: 77,
+  resume_id: 5,
+  project_id: 1,
+  project_name: 'Portfolio Engine',
+  rel_path: 'portfolio-engine',
+  title: 'Portfolio Engine',
+  description: 'Built with React, FastAPI.',
+  analysis_snapshot: ['React', 'FastAPI'],
+  bullet_points: ['Built a desktop portfolio workspace.'],
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-05T00:00:00Z',
+}
+
+const ANALYSIS_RESULT = {
+  name: 'Signal Board',
+  language: 'TypeScript',
+  framework: 'React',
+  tools: ['Vite', 'Jest'],
+  other_languages: ['SQL'],
+  practices: ['Testing'],
+  resume_bullets: ['Built a real-time board for monitoring deploy health.'],
+  ai_bullets: [],
+}
+
+function createApi(overrides = {}) {
+  return {
+    getResumes: jest.fn().mockResolvedValue([]),
+    getProfile: jest.fn().mockResolvedValue(PROFILE),
+    getWorkExperiences: jest.fn().mockResolvedValue([{ id: 1 }]),
+    getEducations: jest.fn().mockResolvedValue([{ id: 1 }]),
+    getProjects: jest.fn().mockResolvedValue([PROJECT_ONE, PROJECT_TWO]),
+    getLLMConfig: jest.fn().mockResolvedValue({ is_allowed: false, model_preferences: [] }),
+    analyzeProject: jest.fn().mockResolvedValue(ANALYSIS_RESULT),
+    createResume: jest.fn().mockResolvedValue({
+      ...EXISTING_RESUME,
+      project_id: 2,
+      project_name: 'Signal Board',
+      title: 'Signal Board',
+      rel_path: 'signal-board',
+      analysis_snapshot: ['TypeScript', 'React', 'Vite'],
+      bullet_points: ['Built a real-time board for monitoring deploy health.'],
+    }),
+    updateResume: jest.fn().mockResolvedValue({
+      ...EXISTING_RESUME,
+      title: 'Updated Resume Entry',
+      bullet_points: ['Updated bullet'],
+    }),
+    deleteResume: jest.fn().mockResolvedValue(null),
+    downloadResumePdf: jest.fn().mockResolvedValue({
+      bytes: new Uint8Array([1, 2, 3]).buffer,
+      contentType: 'application/pdf',
+      filename: 'alice_resume.pdf',
+    }),
+    ...overrides,
+  }
+}
+
+function renderResumesPage(apiOverrides = {}) {
+  window.api = createApi(apiOverrides)
+
+  render(
+    <AppContext.Provider
+      value={{
+        apiOk: true,
+        user: { username: 'alice' },
+      }}
+    >
+      <ResumesPage />
+    </AppContext.Provider>
+  )
+}
+
+function getProjectSelect() {
+  return screen.getAllByRole('combobox')[0]
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  global.URL.createObjectURL = jest.fn(() => 'blob:resume-preview')
+  global.URL.revokeObjectURL = jest.fn()
+})
+
+test('shows the empty state and keeps preview disabled until data is ready', async () => {
+  renderResumesPage({
+    getResumes: jest.fn().mockResolvedValue([]),
+    getProfile: jest.fn().mockResolvedValue(null),
+  })
+
+  await waitFor(() =>
+    expect(screen.getByText(/no resume entries yet/i)).toBeInTheDocument()
+  )
+
+  expect(screen.getByRole('button', { name: /preview pdf/i })).toBeDisabled()
+  expect(screen.getByText(/create your profile before generating the pdf/i)).toBeInTheDocument()
+})
+
+test('creates a resume entry from project analysis with ai assist enabled', async () => {
+  renderResumesPage({
+    getLLMConfig: jest.fn().mockResolvedValue({
+      is_allowed: true,
+      model_preferences: ['Gemini 2.5 Flash (Google)'],
+    }),
+  })
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /\+ add resume entry/i })).toBeInTheDocument()
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /\+ add resume entry/i }))
+
+  fireEvent.change(getProjectSelect(), { target: { value: '2' } })
+
+  await waitFor(() =>
+    expect(window.api.analyzeProject).toHaveBeenCalledWith(2, { useAi: true })
+  )
+
+  await waitFor(() =>
+    expect(screen.getAllByDisplayValue('Signal Board').length).toBeGreaterThan(0)
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /save resume entry/i }))
+
+  await waitFor(() =>
+    expect(window.api.createResume).toHaveBeenCalledWith('alice', {
+      project_id: 2,
+      title: 'Signal Board',
+      description: 'Built with TypeScript, React, Vite, Jest.',
+      bullet_points: ['Built a real-time board for monitoring deploy health.'],
+      analysis_snapshot: ['TypeScript', 'React', 'Vite', 'Jest', 'SQL', 'Testing'],
+    })
+  )
+
+  await waitFor(() =>
+    expect(screen.getAllByText('Signal Board').length).toBeGreaterThan(0)
+  )
+})
+
+test('falls back to local analysis when ai assist fails', async () => {
+  renderResumesPage({
+    getLLMConfig: jest.fn().mockResolvedValue({ is_allowed: true, model_preferences: ['Gemini'] }),
+    analyzeProject: jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Provider unavailable'))
+      .mockResolvedValueOnce(ANALYSIS_RESULT),
+  })
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /\+ add resume entry/i })).toBeInTheDocument()
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /\+ add resume entry/i }))
+  fireEvent.change(getProjectSelect(), { target: { value: '2' } })
+
+  await waitFor(() =>
+    expect(window.api.analyzeProject).toHaveBeenNthCalledWith(1, 2, { useAi: true })
+  )
+  await waitFor(() =>
+    expect(window.api.analyzeProject).toHaveBeenNthCalledWith(2, 2, { useAi: false })
+  )
+
+  await waitFor(() =>
+    expect(screen.getByText(/ai assist failed\. local analysis loaded instead\./i)).toBeInTheDocument()
+  )
+})
+
+test('edits an existing resume entry', async () => {
+  renderResumesPage({
+    getResumes: jest.fn().mockResolvedValue([EXISTING_RESUME]),
+  })
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument()
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /^edit$/i }))
+
+  const titleInput = screen.getByDisplayValue('Portfolio Engine')
+  fireEvent.change(titleInput, { target: { value: 'Updated Resume Entry' } })
+
+  const bulletTextarea = screen.getByDisplayValue('Built a desktop portfolio workspace.')
+  fireEvent.change(bulletTextarea, { target: { value: 'Updated bullet' } })
+
+  fireEvent.click(screen.getByRole('button', { name: /save changes/i }))
+
+  await waitFor(() =>
+    expect(window.api.updateResume).toHaveBeenCalledWith('alice', 1, {
+      title: 'Updated Resume Entry',
+      description: 'Built with React, FastAPI.',
+      bullet_points: ['Updated bullet'],
+      analysis_snapshot: ['React', 'FastAPI'],
+    })
+  )
+})
+
+test('deletes an existing resume entry after confirmation', async () => {
+  renderResumesPage({
+    getResumes: jest.fn().mockResolvedValue([EXISTING_RESUME]),
+  })
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument()
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+  fireEvent.click(screen.getByRole('button', { name: /^yes$/i }))
+
+  await waitFor(() =>
+    expect(window.api.deleteResume).toHaveBeenCalledWith('alice', 1)
+  )
+  await waitFor(() =>
+    expect(screen.queryByText('Portfolio Engine')).not.toBeInTheDocument()
+  )
+})
+
+test('hides already-used projects from the create form', async () => {
+  renderResumesPage({
+    getResumes: jest.fn().mockResolvedValue([EXISTING_RESUME]),
+  })
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /\+ add resume entry/i })).toBeInTheDocument()
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /\+ add resume entry/i }))
+
+  expect(screen.queryByRole('option', { name: 'Portfolio Engine' })).not.toBeInTheDocument()
+  expect(screen.getByRole('option', { name: 'Signal Board' })).toBeInTheDocument()
+})
+
+test('generates and previews a pdf from saved entries', async () => {
+  renderResumesPage({
+    getResumes: jest.fn().mockResolvedValue([EXISTING_RESUME]),
+  })
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /preview pdf/i })).toBeEnabled()
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /preview pdf/i }))
+
+  await waitFor(() =>
+    expect(window.api.downloadResumePdf).toHaveBeenCalledWith('alice', {
+      template_name: 'jake',
+    })
+  )
+
+  await waitFor(() =>
+    expect(screen.getByTitle(/resume pdf preview/i)).toBeInTheDocument()
+  )
+  expect(
+    screen.getAllByRole('button', { name: /download pdf/i }).some((button) => !button.disabled)
+  ).toBe(true)
+})

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -7,6 +7,22 @@ const mockJson = (data, ok = true) =>
     text: () => Promise.resolve(JSON.stringify(data))
   });
 
+const mockBinary = ({ bytes, contentType = 'application/pdf', contentDisposition = 'attachment; filename="resume.pdf"' }) =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    headers: {
+      get: (key) => {
+        if (key === 'content-type') return contentType
+        if (key === 'content-disposition') return contentDisposition
+        return null
+      }
+    },
+    arrayBuffer: () => Promise.resolve(bytes),
+    text: () => Promise.resolve(''),
+    json: () => Promise.resolve({})
+  });
+
 beforeEach(() => {
   jest.resetModules();
   global.fetch = jest.fn();
@@ -104,6 +120,52 @@ describe('api.getWorkExperiences', () => {
   });
 });
 
+describe('api.analyzeProject', () => {
+  it('passes optional analysis query params', async () => {
+    fetch.mockResolvedValue(mockJson({ id: 7 }));
+
+    await global.api.analyzeProject(7, { useAi: true });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/projects/7/analyze?use_ai=true',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});
+
+describe('api.downloadResumePdf', () => {
+  it('returns binary data and filename for resume previews', async () => {
+    const bytes = new Uint8Array([1, 2, 3]).buffer;
+    fetch.mockResolvedValue(
+      mockBinary({
+        bytes,
+        contentDisposition: 'attachment; filename="alice_resume.pdf"',
+      })
+    );
+
+    global.api.setAuthUsername('alice');
+
+    const result = await global.api.downloadResumePdf('alice', { template_name: 'modern' });
+
+    expect(result).toEqual({
+      bytes,
+      contentType: 'application/pdf',
+      filename: 'alice_resume.pdf',
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/users/alice/resumes/generate',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Username': 'alice',
+        },
+        body: JSON.stringify({ template_name: 'modern' }),
+      })
+    );
+  });
+});
+
 describe('error handling', () => {
   it('throws on non-ok response', async () => {
     fetch.mockResolvedValue({
@@ -120,5 +182,19 @@ describe('error handling', () => {
     fetch.mockRejectedValue(new Error('ECONNREFUSED'));
 
     await expect(global.api.getProjects()).rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('throws parsed errors for binary resume requests', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      headers: { get: (key) => key === 'content-type' ? 'application/json' : null },
+      json: () => Promise.resolve({ detail: 'LaTeX compiler not found.' }),
+      text: () => Promise.resolve(JSON.stringify({ detail: 'LaTeX compiler not found.' }))
+    });
+
+    await expect(
+      global.api.downloadResumePdf('alice', { template_name: 'jake' })
+    ).rejects.toThrow('LaTeX compiler not found.');
   });
 });

--- a/frontend/tests/setup.dom.js
+++ b/frontend/tests/setup.dom.js
@@ -6,14 +6,27 @@ global.window.api = {
   health:               jest.fn().mockResolvedValue({ status: 'ok' }),
   getCurrentUser:       jest.fn().mockResolvedValue({ username: 'testuser' }),
   setUsername:          jest.fn(),
+  setAuthUsername:      jest.fn(),
   getUsername:          jest.fn().mockReturnValue(null),
   getProjects:          jest.fn().mockResolvedValue([]),
   getSkills:            jest.fn().mockResolvedValue([]),
+  getProfile:           jest.fn().mockResolvedValue(null),
   getWorkExperiences:   jest.fn().mockResolvedValue([]),
+  getEducations:        jest.fn().mockResolvedValue([]),
   createWorkExperience:  jest.fn().mockResolvedValue({}),
   updateWorkExperience:  jest.fn().mockResolvedValue({}),
   deleteWorkExperience:  jest.fn().mockResolvedValue(null),
   getResumes:           jest.fn().mockResolvedValue([]),
+  createResume:         jest.fn().mockResolvedValue({}),
+  updateResume:         jest.fn().mockResolvedValue({}),
+  deleteResume:         jest.fn().mockResolvedValue(null),
+  analyzeProject:       jest.fn().mockResolvedValue({}),
+  getLLMConfig:         jest.fn().mockResolvedValue({ is_allowed: false, model_preferences: [] }),
+  downloadResumePdf:    jest.fn().mockResolvedValue({
+    bytes: new ArrayBuffer(8),
+    contentType: 'application/pdf',
+    filename: 'resume.pdf',
+  }),
 
   // Consent
   getAvailableServices: jest.fn().mockResolvedValue([


### PR DESCRIPTION
## 📝 Description

Adds the frontend test coverage for the resumes feature stack. This PR covers the renderer workflows and preload bridge behaviors introduced earlier in the stack, including navigation, AI-assisted draft generation, preview rendering, and binary response handling.

**Related Issues:** #371, #387

**Closes:** N/A

---

## 🔧 Type of Change

- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] `npm test -- --runInBand`

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

</details>
