### PR TITLE
docs(readme): add cloud-hosted link to zip2job.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ An application that analyzes code repositories, extracts developer skills, detec
 
 **Tech stack:** Electron + React frontend, FastAPI backend, SQLite database, Gemini AI integration.
 
+**Cloud-hosted:** Try it online at [zip2job.com](https://zip2job.com) — no install required.
+
 ---
 
 ## Documentation


### PR DESCRIPTION
## 📝 Description

Adds a cloud-hosted callout to the top of the README pointing users to [zip2job.com](https://zip2job.com) so they can try the app online without a local install.

Originally deployed on March 17th. Last updated on April 1st. 
https://who.is/whois/zip2job.com

**Closes:** # (n/a)

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

N/A